### PR TITLE
[SA-1550] Updating Charts pod on iOS to support the latest Xcode version

### DIFF
--- a/Charts.podspec
+++ b/Charts.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "Charts"
-  s.version = "4.1.0"
+  s.version = "4.1.1"
   s.summary = "Charts is a powerful & easy to use chart library for iOS, tvOS and OSX (and Android)"
   s.homepage = "https://github.com/danielgindi/Charts"
   s.license = { :type => "Apache License, Version 2.0", :file => "LICENSE" }

--- a/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
@@ -40,9 +40,9 @@ open class ChartDataSet: ChartBaseDataSet
     @objc public init(entries: [ChartDataEntry], label: String)
     {
         self.entries = entries 
-
+        
         super.init(label: label)
-
+        
         self.calcMinMax()
     }
     
@@ -52,13 +52,13 @@ open class ChartDataSet: ChartBaseDataSet
     }
     
     // MARK: - Data functions and accessors
-
+    
     /// - Note: Calls `notifyDataSetChanged()` after setting a new value.
     /// - Returns: The array of y-values that this DataSet represents.
     /// the entries that this dataset represents / holds together
     @objc
     open private(set) var entries: [ChartDataEntry]
-
+    
     /// Used to replace all entries of a data set while retaining styling properties.
     /// This is a separate method from a setter on `entries` to encourage usage
     /// of `Collection` conformances.
@@ -69,7 +69,7 @@ open class ChartDataSet: ChartBaseDataSet
         self.entries = entries
         notifyDataSetChanged()
     }
-
+    
     /// maximum y-value in the value array
     internal var _yMax: Double = -Double.greatestFiniteMagnitude
     
@@ -88,9 +88,9 @@ open class ChartDataSet: ChartBaseDataSet
         _yMin = Double.greatestFiniteMagnitude
         _xMax = -Double.greatestFiniteMagnitude
         _xMin = Double.greatestFiniteMagnitude
-
+        
         guard !isEmpty else { return }
-
+        
         forEach(calcMinMax)
     }
     
@@ -98,7 +98,7 @@ open class ChartDataSet: ChartBaseDataSet
     {
         _yMax = -Double.greatestFiniteMagnitude
         _yMin = Double.greatestFiniteMagnitude
-
+        
         guard !isEmpty else { return }
         
         let indexFrom = entryIndex(x: fromX, closestToY: .nan, rounding: .closest)
@@ -218,9 +218,9 @@ open class ChartDataSet: ChartBaseDataSet
     {
         var closest = partitioningIndex { $0.x >= xValue }
         guard closest < endIndex else { return index(before: endIndex) }
-
+        
         var closestXValue = self[closest].x
-
+        
         switch rounding {
         case .up:
             // If rounding up, and found x-value is lower than specified x, and we can go upper...
@@ -228,14 +228,14 @@ open class ChartDataSet: ChartBaseDataSet
             {
                 formIndex(after: &closest)
             }
-
+            
         case .down:
             // If rounding down, and found x-value is upper than specified x, and we can go lower...
             if closestXValue > xValue && closest > startIndex
             {
                 formIndex(before: &closest)
             }
-
+            
         case .closest:
             // The closest value in the beginning of this function
             // `var closest = partitioningIndex { $0.x >= xValue }`
@@ -250,7 +250,7 @@ open class ChartDataSet: ChartBaseDataSet
                 closestXValue = self[closest].x
             }
         }
-
+        
         // Search by closest to y-value
         if !yValue.isNaN
         {
@@ -258,15 +258,15 @@ open class ChartDataSet: ChartBaseDataSet
             {
                 formIndex(before: &closest)
             }
-
+            
             var closestYValue = self[closest].y
             var closestYIndex = closest
-
+            
             while closest < index(before: endIndex)
             {
                 formIndex(after: &closest)
                 let value = self[closest]
-
+                
                 if value.x != closestXValue { break }
                 if abs(value.y - yValue) <= abs(closestYValue - yValue)
                 {
@@ -274,7 +274,7 @@ open class ChartDataSet: ChartBaseDataSet
                     closestYIndex = closest
                 }
             }
-
+            
             closest = closestYIndex
         }
         
@@ -320,7 +320,7 @@ open class ChartDataSet: ChartBaseDataSet
         {
             let startIndex = entryIndex(x: e.x, closestToY: e.y, rounding: .up)
             let closestIndex = self[startIndex...].lastIndex { $0.x < e.x }
-                ?? startIndex
+            ?? startIndex
             calcMinMax(entry: e)
             entries.insert(e, at: closestIndex)
         }
@@ -337,7 +337,7 @@ open class ChartDataSet: ChartBaseDataSet
     {
         remove(entry)
     }
-
+    
     /// Removes an Entry from the DataSet dynamically.
     /// This will also recalculate the current minimum and maximum values of the DataSet and the value-sum.
     ///
@@ -350,7 +350,7 @@ open class ChartDataSet: ChartBaseDataSet
         _ = remove(at: index)
         return true
     }
-
+    
     /// Removes the first Entry (at index 0) of this DataSet from the entries array.
     ///
     /// - Returns: `true` if successful, `false` if not.
@@ -372,7 +372,7 @@ open class ChartDataSet: ChartBaseDataSet
         let entry: ChartDataEntry? = isEmpty ? nil : removeLast()
         return entry != nil
     }
-
+    
     /// Removes all values from this DataSet and recalculates min and max value.
     @available(*, deprecated, message: "Use `removeAll(keepingCapacity:)` instead.")
     open override func clear()
@@ -393,7 +393,7 @@ open class ChartDataSet: ChartBaseDataSet
         copy._yMin = _yMin
         copy._xMax = _xMax
         copy._xMin = _xMin
-
+        
         return copy
     }
 }
@@ -402,19 +402,19 @@ open class ChartDataSet: ChartBaseDataSet
 extension ChartDataSet: MutableCollection {
     public typealias Index = Int
     public typealias Element = ChartDataEntry
-
+    
     public var startIndex: Index {
         return entries.startIndex
     }
-
+    
     public var endIndex: Index {
         return entries.endIndex
     }
-
+    
     public func index(after: Index) -> Index {
         return entries.index(after: after)
     }
-
+    
     @objc
     public subscript(position: Index) -> Element {
         get {
@@ -447,40 +447,45 @@ extension ChartDataSet: RangeReplaceableCollection {
         calcMinMax(entry: newElement)
         entries.append(newElement)
     }
-
+    
     public func remove(at position: Index) -> Element {
         let element = entries.remove(at: position)
         notifyDataSetChanged()
         return element
     }
-
+    
     public func removeFirst() -> Element {
         let element = entries.removeFirst()
         notifyDataSetChanged()
         return element
     }
-
+    
     public func removeFirst(_ n: Int) {
         entries.removeFirst(n)
         notifyDataSetChanged()
     }
-
+    
     public func removeLast() -> Element {
         let element = entries.removeLast()
         notifyDataSetChanged()
         return element
     }
-
+    
     public func removeLast(_ n: Int) {
         entries.removeLast(n)
         notifyDataSetChanged()
     }
-
+    
     public func removeSubrange<R>(_ bounds: R) where R : RangeExpression, Index == R.Bound {
         entries.removeSubrange(bounds)
         notifyDataSetChanged()
     }
-
+    
+    public func replaceSubrange<C>(_ subrange: Swift.Range<Int>, with newElements: C) where C : Collection, ChartDataEntry == C.Element {
+        entries.replaceSubrange(subrange, with: newElements)
+        notifyDataSetChanged()
+    }
+    
     @objc
     public func removeAll(keepingCapacity keepCapacity: Bool) {
         entries.removeAll(keepingCapacity: keepCapacity)


### PR DESCRIPTION
### Changes
This PR contains a fix for the Charts pod not supporting the latest Xcode versions and giving following errors.

- Type 'ChartDataSet' does not conform to protocol 'RangeReplaceableCollection'
- Unavailable instance method 'replaceSubrange(_:with:)' was used to satisfy a requirement of protocol 'RangeReplaceableCollection'.

Stackoverflow link - https://stackoverflow.com/questions/74010925/charts-not-compile-on-xcode-14